### PR TITLE
Preserve passed-in dialog.dialogClass classes.

### DIFF
--- a/js/jquery.multiDialog.js
+++ b/js/jquery.multiDialog.js
@@ -568,7 +568,7 @@ $.extend( MultiDialog.prototype, {
 		// create dialog
 		this.uiDialog.dialog(
 			$.extend( true, {}, that.options.dialog, {
-				dialogClass: this.widgetName,
+				dialogClass: this.widgetName + ' ' + that.options.dialog.dialogClass,
 				close: function( event ){
 					that._close( event );
 				},


### PR DESCRIPTION
So we can use the dialogClass option from jquery.ui.dialog.
