### PR TITLE
Index is overloaded.

### DIFF
--- a/js/jquery.multiDialog.js
+++ b/js/jquery.multiDialog.js
@@ -495,7 +495,7 @@ $.extend( MultiDialog.prototype, {
 		}
 	},
 
-	index: function( index ) {
+	goto: function( index ) {
 		this._move( index );
 	},
 


### PR DESCRIPTION
This means we can't call this.index(n) from elsewhere.

Relabel to `goto: this._move(n);`
