### PR TITLE
Check for missing group before using.

### DIFF
--- a/js/jquery.multiDialog.js
+++ b/js/jquery.multiDialog.js
@@ -792,8 +792,7 @@ $.extend( MultiDialog.prototype, {
 	},
 
 	_getPositionInfo: function( key ) {
-		if ( ! this.group ) return;
-		if ( this.options.gallery.enabled && this.group.length > 0 && this.options.gallery.showPositionInfo[ key ] && !this.isLoading ) {
+		if ( this.options.gallery.enabled && this.group && this.group.length > 0 && this.options.gallery.showPositionInfo[ key ] && !this.isLoading ) {
 			return "<span class='positon'>" + this.options.gallery.strings.position.replace( "{index}", this.index + 1 ).replace( "{amount}", this.group.length ) + "</span>";
 		}
 


### PR DESCRIPTION
If you instantiate with gallery:true but there is only one image then this.group isn't set and causes _getPositionInfo to fail.
